### PR TITLE
fix: emergencyServicesOptIn type

### DIFF
--- a/policies.d.ts
+++ b/policies.d.ts
@@ -32,7 +32,7 @@ export type Policy = {
   debitDate: string
   effectiveDate: string
   email: string
-  emergencyServicesOptIn: boolean
+  emergencyServicesOptIn: boolean | null
   expirationDate: string
   inForce: boolean
   lastPaymentAmount: string


### PR DESCRIPTION
## Code Impact
Indicates the level of complexity of the changes in relation to the rest of the codebase

| X | Impact    | Description                                                                                              |
|----|-------------|----------------------------------------------------------------------------------------------|
|  X  | Low         | Very few changes were made, or the changes were very simple           |


## Changes
- changes type of `emergencyServicesOptIn` to nullable 

## Related Pulses
- [Types: Policies emergencyServicesOptIn nullable](https://eigtechnology.monday.com/boards/445123190/views/10457206/pulses/1253844421?userId=17549404)